### PR TITLE
1 allow intermediate notes to be edited

### DIFF
--- a/melody.py
+++ b/melody.py
@@ -30,6 +30,8 @@ from pygame.locals import (
     MOUSEBUTTONUP,
     MOUSEBUTTONDOWN,
     MOUSEMOTION,
+    K_UP,
+    K_DOWN,
 )
 MLDY_EXT = '.mldy'
 STEP_COLOUR = (200, 150, 120)
@@ -55,10 +57,11 @@ START_OCTAVE = 3
 PIANO_SAMPLE_DIR = "~/Downloads/Steinway Grand  (DS)/Samples/"
 NAME_START = "Steinway_"
 NAME_END = "_Dyn4_RR1.wav"
+MAX_STORABLE = 12 + 4 #Notes in melody gamut
 
 
 def reset_advance_timer(gap = 500):
-    print('Resetting advance timer')
+    # print('Resetting advance timer')
     pg.time.set_timer(ADVANCE_EVENT, 0)
     pg.time.set_timer(ADVANCE_EVENT, gap)
 
@@ -144,6 +147,7 @@ def main():
     pitch_names = octave3_names + octave4_names
     player.init(pitch_names)
     lines = []
+    play = False #Whether to play the clicked mouse note
     selected_stave = None
     #get the sounds:
     # PATH_TO_A1 = os.path.join(os.path.expanduser(PIANO_SAMPLE_DIR), NAME_START + "A1" + NAME_END)
@@ -155,6 +159,7 @@ def main():
     # c4 = pg.mixer.Sound(PATH_TO_C1)
     pressed = None
     pressed_list = []
+    sel_index = None
     global stored
     stored = []
     index = -1
@@ -182,12 +187,16 @@ def main():
                     if stave_number < len(lines):
                         selected_note_index = bisect.bisect_right(lines[stave_number], pos[0])
                         if selected_note_index < len(lines[stave_number]):
-                            # print(f'selected_note_index = {selected_note_index}, lines[stave_number] = {lines[stave_number]}')
                             selected_stave = (stave_number, lines[stave_number], selected_note_index)
+                            sel_index = max(0, selected_note_index - 1) + sum([len(l) for l in lines[0:stave_number]]) - stave_number
+                            # print(f'selected_note_index = {selected_note_index}, lines[stave_number] = {lines[stave_number]}, sel_index = {sel_index}')
+                            play = True
                         else:
                             selected_stave = None
+                            sel_index = None
                     else:
                         selected_stave = None
+                        sel_index = None
             elif event.type == pg.KEYDOWN:
                 if event.key == pg.K_ESCAPE:
                     running = False
@@ -233,10 +242,18 @@ def main():
                     # step_input = False
                 elif event.key == K_BACKSPACE:
                     if step_input and len(stored) > 0:
-                        print(f'Deleting, len(stored) = {len(stored)}')
+                        # print(f'Deleting, len(stored) = {len(stored)}')
                         stored.pop()
                         # index -= 1
-                        print(f'Deleted, len(stored) = {len(stored)}')
+                        # print(f'Deleted, len(stored) = {len(stored)}')
+                elif event.key == K_UP:
+                    if step_input and sel_index is not None:
+                        stored[sel_index] = min(stored[sel_index] + 1, MAX_STORABLE)
+                        play = True
+                elif event.key == K_DOWN:
+                    if step_input and sel_index is not None:
+                        stored[sel_index] = max(stored[sel_index] - 1, 0)
+                        play = True
                 elif event.key == K_SPACE:
                     step_input = not step_input
                 elif event.unicode == 'X':
@@ -248,14 +265,14 @@ def main():
                     lines = make_times(rhythm, stored)
             elif event.type == ADVANCE_EVENT:
                 if -1 < index < len(stored):
-                    print(f'In Advance: {stored[index]}, from index: {index}')
+                    # print(f'In Advance: {stored[index]}, from index: {index}')
                     to_play = stored[index]
                     index += 1
                     if index >= len(stored):
                         index = -1
-                        print(f'Advance, index reset to -1')
+                        # print(f'Advance, index reset to -1')
                     else:
-                        print(f'Advance, with index = {index}, reset timer')
+                        # print(f'Advance, with index = {index}, reset timer')
                         reset_advance_timer(rhythm[(index-1) % len(rhythm)])
                 else:
                     to_play = None
@@ -270,6 +287,10 @@ def main():
         #     old_index = index
 
         screen.fill(STEP_COLOUR if step_input else (30, 120, 70))
+        if play:
+            if sel_index is not None:
+                player.play(stored[sel_index])
+                play = False
         if (to_play is not None):
             player.play(to_play)
             to_play = None
@@ -277,9 +298,12 @@ def main():
             for p in pressed_list:
                 player.play(p)
             if step_input:
-                stored.append(pressed_list[0])
+                if sel_index is not None:
+                    stored[sel_index] = pressed_list[0]
+                else:
+                    stored.append(pressed_list[0])
                 lines = make_times(rhythm, stored)
-                print(f'Pressed {pressed} with step input. stored is {stored}')
+                # print(f'Pressed {pressed} with step input. stored is {stored}')
                 pressed = None
             pressed_list.clear()
         display(screen, rhythm, stored, index, selected_stave)


### PR DESCRIPTION
Can now be done by selecting the duration the note is at (if in edit mode) and then either playing the note, or using up/down arrows to shift by semitones.